### PR TITLE
Added MassTransit traces and metrics to ServiceDefaults

### DIFF
--- a/src/Sample.ServiceDefaults/Extensions.cs
+++ b/src/Sample.ServiceDefaults/Extensions.cs
@@ -54,14 +54,16 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
+                    .AddRuntimeInstrumentation()
+                    .AddMeter("MassTransit");
             })
             .WithTracing(tracing =>
             {
                 tracing.AddAspNetCoreInstrumentation()
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
-                    .AddHttpClientInstrumentation();
+                    .AddHttpClientInstrumentation()
+                    .AddSource("MassTransit");
             });
 
         builder.AddOpenTelemetryExporters();


### PR DESCRIPTION
I added hard-codes "MassTransit" traces and metrics to the ServiceDefaults project so that the MassTransit traces and metrics will show up on the Aspire console.